### PR TITLE
feat: add match-events leaderboard

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Stack, Typography } from '@mui/material';
+import { Stack, Typography } from '@mui/material';
 import Grid from '@mui/material/Grid';
 import { addWeeks, endOfWeek, format, getWeek, parseISO, startOfWeek } from 'date-fns';
 import nb from 'date-fns/locale/nb';
@@ -6,13 +6,13 @@ import { prisma } from 'lib/prisma';
 import { GetServerSideProps, InferGetServerSidePropsType } from 'next';
 import type { NextPage } from 'next';
 import Head from 'next/head';
-import Link from 'next/link';
 import safeJsonStringify from 'safe-json-stringify';
 
 import { ExtendedNotification } from 'components/AdminMessage';
 import AlertMessage from 'components/AlertMessage';
 import Event, { ExtendedEvent } from 'components/Event';
 import { EventsFilters, getEventsWhereFilter } from 'components/EventsFilters';
+import { MainLinkMenu } from 'components/LinkMenu';
 
 export const getServerSideProps: GetServerSideProps = async ({ query }) => {
   const allFutureEventsQuery = await prisma.event.findMany({
@@ -127,14 +127,7 @@ const Home: NextPage = ({ events, notifications }: InferGetServerSidePropsType<t
       <Head>
         <title>Kalender - Pythons</title>
       </Head>
-      <Stack direction='row' justifyContent='space-between' sx={{ mb: 2 }}>
-        <Typography variant='h1'>Kalender</Typography>
-        <Link href='/statistikk' passHref>
-          <Button color='secondary' component='a' variant='outlined'>
-            Statistikk
-          </Button>
-        </Link>
-      </Stack>
+      <MainLinkMenu sx={{ mb: 2 }} />
       <Stack gap={2}>
         {notifications.map((notification: ExtendedNotification) => (
           <AlertMessage key={notification.id} notification={notification} />

--- a/pages/oppmote.tsx
+++ b/pages/oppmote.tsx
@@ -13,6 +13,7 @@ import {
   Select,
   TextField,
   Typography,
+  TypographyProps,
 } from '@mui/material';
 import { EventType, Team } from '@prisma/client';
 import { getMonth, parseISO, set } from 'date-fns';
@@ -128,6 +129,12 @@ export const getServerSideProps: GetServerSideProps<StatisticsProps> = async ({ 
   };
 };
 
+const TableText = ({ children, sx }: Pick<TypographyProps, 'children' | 'sx'>) => (
+  <Typography component='p' sx={{ fontSize: { xs: '1.2rem', md: '1.5rem' }, ...sx }} variant='h3'>
+    {children}
+  </Typography>
+);
+
 type FormData = {
   from: string;
   to: string;
@@ -224,7 +231,7 @@ const Statistics = ({ players, eventsAmount, teams, eventTypes }: StatisticsProp
         </Accordion>
       </Box>
       <Typography gutterBottom>
-        Med den gitte filtreringen finnes det totalt <b>{eventsAmount}</b> arrangementer.
+        Med nåværende filtrering finnes det totalt <b>{eventsAmount}</b> arrangementer.
       </Typography>
       {(router.query.eventType === 'kamp' || !router.query.eventType) && !router.query.team && (
         <Alert severity='info' sx={{ mb: 1 }} variant='outlined'>
@@ -232,19 +239,18 @@ const Statistics = ({ players, eventsAmount, teams, eventTypes }: StatisticsProp
           andre lags kamper.
         </Alert>
       )}
-      <Divider sx={{ mb: 0.5 }} />
       <Box sx={{ display: 'grid', gridTemplateColumns: 'auto 1fr auto', columnGap: 2, rowGap: 0.5 }}>
+        <TableText sx={{ pl: 0.5, fontWeight: 'bold' }}>#</TableText>
+        <TableText sx={{ fontWeight: 'bold' }}>Navn</TableText>
+        <TableText sx={{ pr: 0.5, fontWeight: 'bold' }}>Antall</TableText>
+        <Divider sx={{ gridColumn: 'span 3' }} />
         {players.map((player, index) => (
           <Fragment key={player.id}>
-            <Typography component='p' sx={{ pl: 0.5, fontSize: { xs: '1.2rem', md: '1.5rem' } }} variant='h3'>
-              {index + 1}.
-            </Typography>
-            <Typography component='p' sx={{ fontSize: { xs: '1.2rem', md: '1.5rem' } }} variant='h3'>
-              {player.name}
-            </Typography>
-            <Typography component='p' sx={{ pr: 0.5, fontSize: { xs: '1.2rem', md: '1.5rem' } }} variant='h3'>
+            <TableText sx={{ pl: 0.5 }}>{index + 1}.</TableText>
+            <TableText sx={{}}>{player.name}</TableText>
+            <TableText sx={{ pr: 0.5 }}>
               {player._count.registrations} ({Math.round((player._count.registrations / eventsAmount) * 100) || 0}%)
-            </Typography>
+            </TableText>
             <Divider sx={{ gridColumn: 'span 3' }} />
           </Fragment>
         ))}

--- a/pages/oppmote.tsx
+++ b/pages/oppmote.tsx
@@ -1,0 +1,256 @@
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Alert,
+  Box,
+  Button,
+  Divider,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { EventType, Team } from '@prisma/client';
+import { getMonth, parseISO, set } from 'date-fns';
+import { prisma } from 'lib/prisma';
+import type { GetServerSideProps } from 'next';
+import Head from 'next/head';
+import { useRouter } from 'next/router';
+import { Fragment, useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import safeJsonStringify from 'safe-json-stringify';
+import { removeFalsyElementsFromObject } from 'utils';
+
+import { MainLinkMenu } from 'components/LinkMenu';
+
+const DEFAULT_TO_DATE = set(new Date(), { hours: 12, minutes: 0 });
+const DEFAULT_FROM_DATE = set(new Date(), { month: getMonth(new Date()) > 6 ? 6 : 0, date: 1, hours: 12, minutes: 0 });
+
+type StatisticsProps = {
+  eventsAmount: number;
+  players: {
+    _count: {
+      registrations: number;
+    };
+    id: number;
+    name: string;
+  }[];
+  teams: Team[];
+  eventTypes: EventType[];
+};
+
+export const getServerSideProps: GetServerSideProps<StatisticsProps> = async ({ query }) => {
+  const dateTo = typeof query.to === 'string' && query.to !== '' ? parseISO(query.to) : DEFAULT_TO_DATE;
+  const dateFrom = typeof query.from === 'string' && query.from !== '' ? parseISO(query.from) : DEFAULT_FROM_DATE;
+  const eventTypeFilter = typeof query.eventType === 'string' && query.eventType !== '' ? query.eventType : undefined;
+  const teamFilter = typeof query.team === 'string' && query.team !== '' ? query.team : undefined;
+  const willArriveFilter =
+    typeof query.willArrive === 'string' && query.team !== '' ? (query.willArrive === 'yes' ? true : query.willArrive === 'no' ? false : null) : undefined;
+
+  if (!query.to && !query.from && !query.eventType && !query.team && !query.willArrive) {
+    return {
+      redirect: {
+        destination: `/oppmote?to=${DEFAULT_TO_DATE.toJSON().substring(0, 10)}&from=${DEFAULT_FROM_DATE.toJSON().substring(
+          0,
+          10,
+        )}&eventType=trening&willArrive=yes`,
+        permanent: false,
+      },
+    };
+  }
+
+  const eventsAmountQuery = prisma.event.aggregate({
+    _count: true,
+    where: {
+      AND: {
+        time: {
+          gte: dateFrom,
+          lte: dateTo,
+        },
+        eventTypeSlug: eventTypeFilter ? { in: eventTypeFilter.split(',') } : undefined,
+      },
+      ...(teamFilter ? { OR: [{ teamId: null }, { teamId: Number(teamFilter) }] } : {}),
+    },
+  });
+
+  const playersQuery = prisma.player.findMany({
+    where: {
+      active: true,
+      teamId: teamFilter ? Number(teamFilter) : undefined,
+    },
+    select: {
+      id: true,
+      name: true,
+      _count: {
+        select: {
+          registrations: {
+            where: {
+              willArrive: willArriveFilter === null ? undefined : willArriveFilter,
+              event: {
+                AND: {
+                  time: {
+                    gte: dateFrom,
+                    lt: dateTo,
+                  },
+                  eventTypeSlug: eventTypeFilter ? { in: eventTypeFilter.split(',') } : undefined,
+                },
+                ...(teamFilter ? { OR: [{ teamId: null }, { teamId: Number(teamFilter) }] } : {}),
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  const teamsQuery = prisma.team.findMany();
+  const eventTypesQuery = prisma.eventType.findMany();
+
+  const [eventsAmount, players, teams, eventTypes] = await Promise.all([eventsAmountQuery, playersQuery, teamsQuery, eventTypesQuery]);
+  const sortedPlayers = players
+    .map((player) => ({
+      ...player,
+      _count: { registrations: willArriveFilter === null ? eventsAmount._count - player._count.registrations : player._count.registrations },
+    }))
+    .sort((a, b) => b._count.registrations - a._count.registrations);
+
+  return {
+    props: {
+      eventsAmount: eventsAmount._count,
+      players: sortedPlayers,
+      teams: JSON.parse(safeJsonStringify(teams)),
+      eventTypes: JSON.parse(safeJsonStringify(eventTypes)),
+    },
+  };
+};
+
+type FormData = {
+  from: string;
+  to: string;
+  eventType: string;
+  team: string;
+  willArrive: string;
+};
+
+const Statistics = ({ players, eventsAmount, teams, eventTypes }: StatisticsProps) => {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const { handleSubmit, control } = useForm<FormData>({
+    defaultValues: {
+      to: typeof router.query.to === 'string' && router.query.to !== '' ? router.query.to : DEFAULT_TO_DATE.toJSON().substring(0, 10),
+      from: typeof router.query.from === 'string' && router.query.from !== '' ? router.query.from : DEFAULT_FROM_DATE.toJSON().substring(0, 10),
+      eventType: typeof router.query.eventType === 'string' ? router.query.eventType : '',
+      team: typeof router.query.team === 'string' ? router.query.team : '',
+      willArrive: typeof router.query.willArrive === 'string' ? router.query.willArrive : '',
+    },
+  });
+
+  const onSubmit = async (query: FormData) => {
+    router.replace({ query: removeFalsyElementsFromObject(query) });
+    setOpen(false);
+  };
+
+  return (
+    <>
+      <Head>
+        <title>Oppmøte - Pythons</title>
+      </Head>
+      <MainLinkMenu sx={{ mb: 2 }} />
+      <Box sx={{ mb: 2 }}>
+        <Accordion expanded={open} onChange={() => setOpen((prev) => !prev)} sx={{ backgroundColor: '#001731' }}>
+          <AccordionSummary expandIcon={<ExpandMoreIcon />}>Filtrering</AccordionSummary>
+          <AccordionDetails>
+            <Box component='form' onSubmit={handleSubmit(onSubmit)} sx={{ pt: 1, display: 'grid', gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' }, gap: 1 }}>
+              <Controller control={control} name='from' render={({ field }) => <TextField label='Fra' type='date' {...field} />} />
+              <Controller control={control} name='to' render={({ field }) => <TextField label='Til' type='date' {...field} />} />
+              <FormControl fullWidth>
+                <InputLabel id='selectType-type'>Type</InputLabel>
+                <Controller
+                  control={control}
+                  name='eventType'
+                  render={({ field }) => (
+                    <Select id='type' label='Type' labelId='selectType-type' {...field}>
+                      <MenuItem value=''>Alle</MenuItem>
+                      {eventTypes.map((eventType) => (
+                        <MenuItem key={eventType.slug} value={eventType.slug}>
+                          {eventType.name}
+                        </MenuItem>
+                      ))}
+                    </Select>
+                  )}
+                />
+              </FormControl>
+              <FormControl fullWidth>
+                <InputLabel id='select-team'>Lag</InputLabel>
+                <Controller
+                  control={control}
+                  name='team'
+                  render={({ field }) => (
+                    <Select id='team' label='Lag' labelId='select-team' {...field}>
+                      <MenuItem value=''>Alle</MenuItem>
+                      {teams.map((team) => (
+                        <MenuItem key={team.id} value={team.id}>
+                          {team.name}
+                        </MenuItem>
+                      ))}
+                    </Select>
+                  )}
+                />
+              </FormControl>
+              <FormControl fullWidth>
+                <InputLabel id='select-willArrive'>Oppmøte</InputLabel>
+                <Controller
+                  control={control}
+                  name='willArrive'
+                  render={({ field }) => (
+                    <Select id='willArrive' label='Oppmøte' labelId='select-willArrive' {...field}>
+                      <MenuItem value=''>Alle</MenuItem>
+                      <MenuItem value='yes'>Ja</MenuItem>
+                      <MenuItem value='no'>Nei</MenuItem>
+                      <MenuItem value='none'>Ikke registrert</MenuItem>
+                    </Select>
+                  )}
+                />
+              </FormControl>
+              <Button sx={{ gridColumn: { xs: undefined, md: 'span 2' } }} type='submit' variant='contained'>
+                Oppdater filtre
+              </Button>
+            </Box>
+          </AccordionDetails>
+        </Accordion>
+      </Box>
+      <Typography gutterBottom>
+        Med den gitte filtreringen finnes det totalt <b>{eventsAmount}</b> arrangementer.
+      </Typography>
+      {(router.query.eventType === 'kamp' || !router.query.eventType) && !router.query.team && (
+        <Alert severity='info' sx={{ mb: 1 }} variant='outlined'>
+          Kamper er en del av filtreringen uten at et lag er valgt. Det medfører at ingen kan ha 100% påmeldinger ettersom det ikke er mulig å melde seg på
+          andre lags kamper.
+        </Alert>
+      )}
+      <Divider sx={{ mb: 0.5 }} />
+      <Box sx={{ display: 'grid', gridTemplateColumns: 'auto 1fr auto', columnGap: 2, rowGap: 0.5 }}>
+        {players.map((player, index) => (
+          <Fragment key={player.id}>
+            <Typography component='p' sx={{ pl: 0.5, fontSize: { xs: '1.2rem', md: '1.5rem' } }} variant='h3'>
+              {index + 1}.
+            </Typography>
+            <Typography component='p' sx={{ fontSize: { xs: '1.2rem', md: '1.5rem' } }} variant='h3'>
+              {player.name}
+            </Typography>
+            <Typography component='p' sx={{ pr: 0.5, fontSize: { xs: '1.2rem', md: '1.5rem' } }} variant='h3'>
+              {player._count.registrations} ({Math.round((player._count.registrations / eventsAmount) * 100) || 0}%)
+            </Typography>
+            <Divider sx={{ gridColumn: 'span 3' }} />
+          </Fragment>
+        ))}
+      </Box>
+    </>
+  );
+};
+
+export default Statistics;

--- a/pages/statistikk.tsx
+++ b/pages/statistikk.tsx
@@ -1,97 +1,54 @@
-import { Alert, Box, Button, Divider, FormControl, InputLabel, MenuItem, Select, Stack, TextField, Typography } from '@mui/material';
-import { EventType, Team } from '@prisma/client';
-import { getMonth, parseISO, set } from 'date-fns';
+import { Box, Divider, FormControl, InputLabel, MenuItem, Select, Stack, Typography } from '@mui/material';
+import { SelectChangeEvent } from '@mui/material/Select';
+import { MatchEventType, Player, Team } from '@prisma/client';
 import { prisma } from 'lib/prisma';
 import type { GetServerSideProps } from 'next';
 import Head from 'next/head';
-import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { Fragment } from 'react';
-import { Controller, useForm } from 'react-hook-form';
+import { Fragment, useState } from 'react';
 import safeJsonStringify from 'safe-json-stringify';
+import { getSemesters, MATCH_EVENT_TYPES, removeFalsyElementsFromObject } from 'utils';
 
-const removeFalsyElementsFromObject = (object: Record<string, string>) => {
-  const newObject: Record<string, string> = {};
-  Object.keys(object).forEach((key) => {
-    if (object[key]) {
-      newObject[key] = object[key];
-    }
-  });
-  return newObject;
-};
+import { MainLinkMenu } from 'components/LinkMenu';
 
-const DEFAULT_TO_DATE = set(new Date(), { hours: 12, minutes: 0 });
-const DEFAULT_FROM_DATE = set(new Date(), { month: getMonth(new Date()) > 6 ? 6 : 0, date: 1, hours: 12, minutes: 0 });
+const semesters = getSemesters();
 
 type StatisticsProps = {
-  eventsAmount: number;
-  players: {
-    _count: {
-      registrations: number;
-    };
-    id: number;
-    name: string;
-  }[];
   teams: Team[];
-  eventTypes: EventType[];
+  players: (Player & {
+    _count: {
+      matchEvents: number;
+    };
+  })[];
 };
 
 export const getServerSideProps: GetServerSideProps<StatisticsProps> = async ({ query }) => {
-  const dateTo = typeof query.to === 'string' && query.to !== '' ? parseISO(query.to) : DEFAULT_TO_DATE;
-  const dateFrom = typeof query.from === 'string' && query.from !== '' ? parseISO(query.from) : DEFAULT_FROM_DATE;
-  const eventTypeFilter = typeof query.eventType === 'string' && query.eventType !== '' ? query.eventType : undefined;
-  const teamFilter = typeof query.team === 'string' && query.team !== '' ? query.team : undefined;
-  const willArriveFilter =
-    typeof query.willArrive === 'string' && query.team !== '' ? (query.willArrive === 'yes' ? true : query.willArrive === 'no' ? false : null) : undefined;
-
-  if (!query.to && !query.from && !query.eventType && !query.team && !query.willArrive) {
-    return {
-      redirect: {
-        destination: `/statistikk?to=${DEFAULT_TO_DATE.toJSON().substring(0, 10)}&from=${DEFAULT_FROM_DATE.toJSON().substring(
-          0,
-          10,
-        )}&eventType=trening&willArrive=yes`,
-        permanent: false,
-      },
-    };
-  }
-
-  const eventsAmountQuery = prisma.event.aggregate({
-    _count: true,
-    where: {
-      AND: {
-        time: {
-          gte: dateFrom,
-          lte: dateTo,
-        },
-        eventTypeSlug: eventTypeFilter ? { in: eventTypeFilter.split(',') } : undefined,
-      },
-      ...(teamFilter ? { OR: [{ teamId: null }, { teamId: Number(teamFilter) }] } : {}),
-    },
-  });
+  const semesterFilter = typeof query.semester === 'string' && query.semester !== '' ? semesters.find((semester) => semester.id === query.semester) : undefined;
+  const teamFilter = typeof query.team === 'string' && query.team !== '' ? Number(query.team) : undefined;
+  const matchEventTypeFilter =
+    typeof query.matchEventType === 'string' && query.matchEventType !== '' ? (query.matchEventType as MatchEventType) : MatchEventType.GOAL;
 
   const playersQuery = prisma.player.findMany({
-    where: {
-      active: true,
-      teamId: teamFilter ? Number(teamFilter) : undefined,
-    },
-    select: {
-      id: true,
-      name: true,
+    include: {
       _count: {
         select: {
-          registrations: {
+          matchEvents: {
             where: {
-              willArrive: willArriveFilter === null ? undefined : willArriveFilter,
-              event: {
-                AND: {
-                  time: {
-                    gte: dateFrom,
-                    lt: dateTo,
+              type: matchEventTypeFilter,
+              match: {
+                is: {
+                  teamId: teamFilter,
+                  event: {
+                    is: {
+                      time: semesterFilter
+                        ? {
+                            gte: semesterFilter.from,
+                            lte: semesterFilter.to,
+                          }
+                        : undefined,
+                    },
                   },
-                  eventTypeSlug: eventTypeFilter ? { in: eventTypeFilter.split(',') } : undefined,
                 },
-                ...(teamFilter ? { OR: [{ teamId: null }, { teamId: Number(teamFilter) }] } : {}),
               },
             },
           },
@@ -101,130 +58,89 @@ export const getServerSideProps: GetServerSideProps<StatisticsProps> = async ({ 
   });
 
   const teamsQuery = prisma.team.findMany();
-  const eventTypesQuery = prisma.eventType.findMany();
 
-  const [eventsAmount, players, teams, eventTypes] = await Promise.all([eventsAmountQuery, playersQuery, teamsQuery, eventTypesQuery]);
-  const sortedPlayers = players
-    .map((player) => ({
-      ...player,
-      _count: { registrations: willArriveFilter === null ? eventsAmount._count - player._count.registrations : player._count.registrations },
-    }))
-    .sort((a, b) => b._count.registrations - a._count.registrations);
+  const [teams, players] = await Promise.all([teamsQuery, playersQuery]);
+  const sortedPlayers = players.filter((player) => player._count.matchEvents > 0).sort((a, b) => b._count.matchEvents - a._count.matchEvents);
 
   return {
     props: {
-      eventsAmount: eventsAmount._count,
-      players: sortedPlayers,
+      players: JSON.parse(safeJsonStringify(sortedPlayers)),
       teams: JSON.parse(safeJsonStringify(teams)),
-      eventTypes: JSON.parse(safeJsonStringify(eventTypes)),
     },
   };
 };
 
-type FormData = {
-  from: string;
-  to: string;
-  eventType: string;
+type Filters = {
+  semester: string;
   team: string;
-  willArrive: string;
+  matchEventType: MatchEventType;
 };
 
-const Statistics = ({ players, eventsAmount, teams, eventTypes }: StatisticsProps) => {
-  const router = useRouter();
-  const { handleSubmit, control } = useForm<FormData>({
-    defaultValues: {
-      to: typeof router.query.to === 'string' && router.query.to !== '' ? router.query.to : DEFAULT_TO_DATE.toJSON().substring(0, 10),
-      from: typeof router.query.from === 'string' && router.query.from !== '' ? router.query.from : DEFAULT_FROM_DATE.toJSON().substring(0, 10),
-      eventType: typeof router.query.eventType === 'string' ? router.query.eventType : '',
-      team: typeof router.query.team === 'string' ? router.query.team : '',
-      willArrive: typeof router.query.willArrive === 'string' ? router.query.willArrive : '',
-    },
+const Statistics = ({ teams, players }: StatisticsProps) => {
+  const { replace, query } = useRouter();
+  const [filters, setFilters] = useState<Filters>({
+    semester: typeof query.semester === 'string' ? query.semester : '',
+    team: typeof query.team === 'string' ? query.team : '',
+    matchEventType: typeof query.matchEventType === 'string' ? (query.matchEventType as MatchEventType) : MatchEventType.GOAL,
   });
 
-  const onSubmit = async (query: FormData) => router.replace({ query: removeFalsyElementsFromObject(query) });
+  const handleChange = (event: SelectChangeEvent, field: keyof Filters) => {
+    const newFilters = { ...filters, [field]: event.target.value as string };
+    setFilters(newFilters);
+    replace({ query: removeFalsyElementsFromObject(newFilters) });
+  };
 
   return (
     <>
       <Head>
         <title>Statistikk - Pythons</title>
       </Head>
-      <Stack direction='row' justifyContent='space-between' sx={{ mb: 2 }}>
-        <Typography variant='h1'>Statistikk</Typography>
-        <Link href='/' passHref>
-          <Button color='secondary' component='a' variant='outlined'>
-            Kalender
-          </Button>
-        </Link>
-      </Stack>
-      <Box component='form' onSubmit={handleSubmit(onSubmit)} sx={{ pt: 1, display: 'grid', gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' }, gap: 1 }}>
-        <Controller control={control} name='from' render={({ field }) => <TextField label='Fra' type='date' {...field} />} />
-        <Controller control={control} name='to' render={({ field }) => <TextField label='Til' type='date' {...field} />} />
+      <MainLinkMenu sx={{ mb: 2 }} />
+      <Stack direction='row' gap={1} sx={{ mb: 2 }}>
         <FormControl fullWidth>
-          <InputLabel id='selectType-type'>Type</InputLabel>
-          <Controller
-            control={control}
-            name='eventType'
-            render={({ field }) => (
-              <Select id='type' label='Type' labelId='selectType-type' {...field}>
-                <MenuItem value=''>Alle</MenuItem>
-                {eventTypes.map((eventType) => (
-                  <MenuItem key={eventType.slug} value={eventType.slug}>
-                    {eventType.name}
-                  </MenuItem>
-                ))}
-              </Select>
-            )}
-          />
+          <InputLabel id='select-semester'>Semester</InputLabel>
+          <Select
+            id='semester'
+            label='Semester'
+            labelId='select-semester'
+            onChange={(e) => handleChange(e as SelectChangeEvent<string>, 'semester')}
+            value={filters.semester}>
+            <MenuItem value=''>Alle</MenuItem>
+            {semesters.map((semester) => (
+              <MenuItem key={semester.id} value={semester.id}>
+                {semester.label}
+              </MenuItem>
+            ))}
+          </Select>
         </FormControl>
         <FormControl fullWidth>
           <InputLabel id='select-team'>Lag</InputLabel>
-          <Controller
-            control={control}
-            name='team'
-            render={({ field }) => (
-              <Select id='team' label='Lag' labelId='select-team' {...field}>
-                <MenuItem value=''>Alle</MenuItem>
-                {teams.map((team) => (
-                  <MenuItem key={team.id} value={team.id}>
-                    {team.name}
-                  </MenuItem>
-                ))}
-              </Select>
-            )}
-          />
+          <Select id='team' label='Lag' labelId='select-team' onChange={(e) => handleChange(e as SelectChangeEvent<string>, 'team')} value={filters.team}>
+            <MenuItem value=''>Alle</MenuItem>
+            {teams.map((team) => (
+              <MenuItem key={team.id} value={team.id}>
+                {team.name}
+              </MenuItem>
+            ))}
+          </Select>
         </FormControl>
         <FormControl fullWidth>
-          <InputLabel id='select-willArrive'>Oppmøte</InputLabel>
-          <Controller
-            control={control}
-            name='willArrive'
-            render={({ field }) => (
-              <Select id='willArrive' label='Oppmøte' labelId='select-willArrive' {...field}>
-                <MenuItem value=''>Alle</MenuItem>
-                <MenuItem value='yes'>Ja</MenuItem>
-                <MenuItem value='no'>Nei</MenuItem>
-                <MenuItem value='none'>Ikke registrert</MenuItem>
-              </Select>
-            )}
-          />
+          <InputLabel id='type-label'>Type</InputLabel>
+          <Select
+            id='type'
+            label='Type'
+            labelId='type-label'
+            onChange={(e) => handleChange(e as SelectChangeEvent<string>, 'matchEventType')}
+            required
+            value={filters.matchEventType}>
+            <MenuItem value={MatchEventType.GOAL}>{MATCH_EVENT_TYPES[MatchEventType.GOAL]}</MenuItem>
+            <MenuItem value={MatchEventType.ASSIST}>{MATCH_EVENT_TYPES[MatchEventType.ASSIST]}</MenuItem>
+            <MenuItem value={MatchEventType.RED_CARD}>{MATCH_EVENT_TYPES[MatchEventType.RED_CARD]}</MenuItem>
+            <MenuItem value={MatchEventType.YELLOW_CARD}>{MATCH_EVENT_TYPES[MatchEventType.YELLOW_CARD]}</MenuItem>
+            <MenuItem value={MatchEventType.MOTM}>{MATCH_EVENT_TYPES[MatchEventType.MOTM]}</MenuItem>
+          </Select>
         </FormControl>
-        <Button sx={{ gridColumn: { xs: undefined, md: 'span 2' } }} type='submit' variant='contained'>
-          Oppdater filtre
-        </Button>
-      </Box>
-      <Divider sx={{ mt: 1, mb: 2 }} />
-      <Typography gutterBottom variant='h2'>
-        Oppmøte-ledertavle
-      </Typography>
-      <Typography gutterBottom>
-        Med den gitte filtreringen finnes det totalt <b>{eventsAmount}</b> arrangementer.
-      </Typography>
-      {(router.query.eventType === 'kamp' || !router.query.eventType) && !router.query.team && (
-        <Alert severity='info' sx={{ mb: 1 }} variant='outlined'>
-          Kamper er en del av filtreringen uten at et lag er valgt. Det medfører at ingen kan ha 100% påmeldinger ettersom det ikke er mulig å melde seg på
-          andre lags kamper.
-        </Alert>
-      )}
+      </Stack>
       <Divider sx={{ mb: 0.5 }} />
       <Box sx={{ display: 'grid', gridTemplateColumns: 'auto 1fr auto', columnGap: 2, rowGap: 0.5 }}>
         {players.map((player, index) => (
@@ -236,7 +152,7 @@ const Statistics = ({ players, eventsAmount, teams, eventTypes }: StatisticsProp
               {player.name}
             </Typography>
             <Typography component='p' sx={{ pr: 0.5, fontSize: { xs: '1.2rem', md: '1.5rem' } }} variant='h3'>
-              {player._count.registrations} ({Math.round((player._count.registrations / eventsAmount) * 100) || 0}%)
+              {player._count.matchEvents}
             </Typography>
             <Divider sx={{ gridColumn: 'span 3' }} />
           </Fragment>

--- a/src/components/Event.tsx
+++ b/src/components/Event.tsx
@@ -275,21 +275,17 @@ const Event = ({ eventDetails }: EventProps) => {
           <>
             {!openRegistration ? (
               <>
-                {isFuture(new Date(eventDetails.time)) ? (
+                {isFuture(new Date(eventDetails.time)) && (
                   <Button disabled={!user} onClick={() => setOpenRegistration(true)} variant={userHasRegistrated ? 'text' : 'contained'}>
                     {userHasRegistrated ? 'Endre' : 'Registrer'} oppmøte
                   </Button>
-                ) : (
-                  <Typography textAlign='center' variant='body2'>
-                    Oppmøte kan ikke endres etter arrangementsstart
-                  </Typography>
                 )}
                 {(eventDetails.type.slug === 'trening' || eventDetails.type.slug === 'kamp') && (
                   <Typography textAlign='center' variant='body2'>
-                    {`Påmeldingsfrist ${formatDistanceToNow(registrationDeadline, { locale: nb, addSuffix: true })} - kl. ${format(
-                      registrationDeadline,
-                      'HH:mm',
-                    )}`}
+                    {`Påmeldingsfrist ${isPast(registrationDeadline) ? 'var ' : ''}${formatDistanceToNow(registrationDeadline, {
+                      locale: nb,
+                      addSuffix: true,
+                    })} - kl. ${format(registrationDeadline, 'HH:mm')}`}
                   </Typography>
                 )}
               </>

--- a/src/components/EventsFilters.tsx
+++ b/src/components/EventsFilters.tsx
@@ -133,7 +133,7 @@ export const EventsFilters = (props: StackProps) => {
           size='large'
           sx={{ fontWeight: view === 'matches' ? 'bold' : undefined }}
           variant={view === 'matches' ? 'contained' : 'outlined'}>
-          Kun kamper
+          Terminliste
         </Button>
       </Stack>
       {view === 'all' ? (

--- a/src/components/EventsFilters.tsx
+++ b/src/components/EventsFilters.tsx
@@ -1,5 +1,19 @@
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import { Accordion, AccordionDetails, AccordionSummary, Box, BoxProps, Button, FormControl, InputLabel, MenuItem, Select, TextField } from '@mui/material';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Button,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  SelectChangeEvent,
+  Stack,
+  StackProps,
+  TextField,
+} from '@mui/material';
 import { EventType, Prisma, Team } from '@prisma/client';
 import { addMonths, isFuture, parseISO, startOfToday } from 'date-fns';
 import { useRouter } from 'next/router';
@@ -7,15 +21,16 @@ import { ParsedUrlQuery } from 'querystring';
 import { useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import useSWR from 'swr';
-import { fetcher, removeFalsyElementsFromObject } from 'utils';
+import { fetcher, getSemesters, removeFalsyElementsFromObject } from 'utils';
 
 const DEFAULT_FROM_DATE = startOfToday();
 const DEFAULT_TO_DATE = addMonths(DEFAULT_FROM_DATE, 2);
 
 export const getEventsWhereFilter = ({ query }: { query: ParsedUrlQuery }): Prisma.EventFindManyArgs => {
-  const dateFrom = typeof query.from === 'string' && query.from !== '' ? parseISO(query.from) : DEFAULT_FROM_DATE;
-  const dateTo = typeof query.to === 'string' && query.to !== '' ? parseISO(query.to) : DEFAULT_TO_DATE;
-  const eventTypeFilter = typeof query.eventType === 'string' && query.eventType !== '' ? query.eventType : undefined;
+  const semester = typeof query.semester === 'string' && query.semester !== '' ? semesters.find((semester) => semester.id === query.semester) : undefined;
+  const dateFrom = semester ? semester.from : typeof query.from === 'string' && query.from !== '' ? parseISO(query.from) : DEFAULT_FROM_DATE;
+  const dateTo = semester ? semester.to : typeof query.to === 'string' && query.to !== '' ? parseISO(query.to) : DEFAULT_TO_DATE;
+  const eventTypeFilter = semester ? 'kamp' : typeof query.eventType === 'string' && query.eventType !== '' ? query.eventType : undefined;
   const teamFilter = typeof query.team === 'string' && query.team !== '' ? query.team : undefined;
 
   return {
@@ -35,20 +50,32 @@ export const getEventsWhereFilter = ({ query }: { query: ParsedUrlQuery }): Pris
   };
 };
 
-type FormData = {
+type MatchesFilters = {
+  semester: string;
+  team: string;
+};
+
+type AllEventsFilters = {
   from: string;
   to: string;
   eventType: string;
   team: string;
 };
 
-export const EventsFilters = (props: BoxProps) => {
+const semesters = getSemesters();
+
+export const EventsFilters = (props: StackProps) => {
   const router = useRouter();
   const { data: teams = [] } = useSWR<Team[]>('/api/teams', fetcher);
   const { data: eventTypes = [] } = useSWR<EventType[]>('/api/eventType', fetcher);
   const [open, setOpen] = useState(false);
+  const [view, setView] = useState<'all' | 'matches'>('all');
+  const [matchesFilters, setMatchesFilters] = useState<MatchesFilters>({
+    semester: typeof router.query.semester === 'string' ? router.query.semester : '',
+    team: typeof router.query.team === 'string' ? router.query.team : '',
+  });
 
-  const { handleSubmit, control, reset } = useForm<FormData>({
+  const { handleSubmit, control, reset } = useForm<AllEventsFilters>({
     defaultValues: {
       to: typeof router.query.to === 'string' && router.query.to !== '' ? router.query.to : DEFAULT_TO_DATE.toJSON().substring(0, 10),
       from: typeof router.query.from === 'string' && router.query.from !== '' ? router.query.from : DEFAULT_FROM_DATE.toJSON().substring(0, 10),
@@ -57,7 +84,7 @@ export const EventsFilters = (props: BoxProps) => {
     },
   });
 
-  const onSubmit = async (query: Partial<FormData>) => {
+  const onSubmit = async (query: Partial<AllEventsFilters>) => {
     router.replace({ query: removeFalsyElementsFromObject(query) });
     setOpen(false);
   };
@@ -66,57 +93,139 @@ export const EventsFilters = (props: BoxProps) => {
     reset();
   };
 
+  const handleChange = (event: SelectChangeEvent, field: keyof MatchesFilters) => {
+    const newFilters: MatchesFilters = { ...matchesFilters, [field]: event.target.value as string };
+    updateMatchesFilters(newFilters);
+  };
+
+  const updateMatchesFilters = (newFilters: MatchesFilters) => {
+    setMatchesFilters(newFilters);
+    router.replace({ query: removeFalsyElementsFromObject(newFilters) });
+  };
+
+  const changeView = (newView: typeof view) => {
+    if (newView === 'all') {
+      clearFilters();
+    }
+    if (newView === 'matches') {
+      const newFilters: MatchesFilters = { semester: semesters[semesters.length - 1].id, team: '' };
+      updateMatchesFilters(newFilters);
+    }
+    setView(newView);
+  };
+
   return (
-    <Box {...props}>
-      <Accordion expanded={open} onChange={() => setOpen((prev) => !prev)} sx={{ backgroundColor: '#001731' }}>
-        <AccordionSummary expandIcon={<ExpandMoreIcon />}>Filtrering</AccordionSummary>
-        <AccordionDetails>
-          <Box component='form' onSubmit={handleSubmit(onSubmit)} sx={{ pt: 1, display: 'grid', gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' }, gap: 1 }}>
-            <Controller control={control} name='from' render={({ field }) => <TextField label='Fra' type='date' {...field} />} />
-            <Controller control={control} name='to' render={({ field }) => <TextField label='Til' type='date' {...field} />} />
-            <FormControl fullWidth>
-              <InputLabel id='selectType-type'>Type</InputLabel>
-              <Controller
-                control={control}
-                name='eventType'
-                render={({ field }) => (
-                  <Select id='type' label='Type' labelId='selectType-type' {...field}>
-                    <MenuItem value=''>Alle</MenuItem>
-                    {eventTypes.map((eventType) => (
-                      <MenuItem key={eventType.slug} value={eventType.slug}>
-                        {eventType.name}
-                      </MenuItem>
-                    ))}
-                  </Select>
-                )}
-              />
-            </FormControl>
-            <FormControl fullWidth>
-              <InputLabel id='select-team'>Lag</InputLabel>
-              <Controller
-                control={control}
-                name='team'
-                render={({ field }) => (
-                  <Select id='team' label='Lag' labelId='select-team' {...field}>
-                    <MenuItem value=''>Alle</MenuItem>
-                    {teams.map((team) => (
-                      <MenuItem key={team.id} value={team.id}>
-                        {team.name}
-                      </MenuItem>
-                    ))}
-                  </Select>
-                )}
-              />
-            </FormControl>
-            <Button sx={{ gridColumn: { xs: undefined, md: 'span 2' } }} type='submit' variant='contained'>
-              Oppdater filtre
-            </Button>
-            <Button onClick={clearFilters} sx={{ gridColumn: { xs: undefined, md: 'span 2' } }} variant='outlined'>
-              Fjern filtre
-            </Button>
-          </Box>
-        </AccordionDetails>
-      </Accordion>
-    </Box>
+    <Stack gap={2} {...props}>
+      <Stack direction='row' gap={1}>
+        <Button
+          color='menu'
+          fullWidth
+          onClick={() => changeView('all')}
+          size='large'
+          sx={{ fontWeight: view === 'all' ? 'bold' : undefined }}
+          variant={view === 'all' ? 'contained' : 'outlined'}>
+          Alle
+        </Button>
+        <Button
+          color='menu'
+          fullWidth
+          onClick={() => changeView('matches')}
+          size='large'
+          sx={{ fontWeight: view === 'matches' ? 'bold' : undefined }}
+          variant={view === 'matches' ? 'contained' : 'outlined'}>
+          Kun kamper
+        </Button>
+      </Stack>
+      {view === 'all' ? (
+        <Box>
+          <Accordion expanded={open} onChange={() => setOpen((prev) => !prev)} sx={{ backgroundColor: '#001731' }}>
+            <AccordionSummary expandIcon={<ExpandMoreIcon />}>Filtrering</AccordionSummary>
+            <AccordionDetails>
+              <Box
+                component='form'
+                onSubmit={handleSubmit(onSubmit)}
+                sx={{ pt: 1, display: 'grid', gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' }, gap: 1 }}>
+                <Controller control={control} name='from' render={({ field }) => <TextField label='Fra' type='date' {...field} />} />
+                <Controller control={control} name='to' render={({ field }) => <TextField label='Til' type='date' {...field} />} />
+                <FormControl fullWidth>
+                  <InputLabel id='selectType-type'>Type</InputLabel>
+                  <Controller
+                    control={control}
+                    name='eventType'
+                    render={({ field }) => (
+                      <Select id='type' label='Type' labelId='selectType-type' {...field}>
+                        <MenuItem value=''>Alle</MenuItem>
+                        {eventTypes.map((eventType) => (
+                          <MenuItem key={eventType.slug} value={eventType.slug}>
+                            {eventType.name}
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    )}
+                  />
+                </FormControl>
+                <FormControl fullWidth>
+                  <InputLabel id='select-team'>Lag</InputLabel>
+                  <Controller
+                    control={control}
+                    name='team'
+                    render={({ field }) => (
+                      <Select id='team' label='Lag' labelId='select-team' {...field}>
+                        <MenuItem value=''>Alle</MenuItem>
+                        {teams.map((team) => (
+                          <MenuItem key={team.id} value={team.id}>
+                            {team.name}
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    )}
+                  />
+                </FormControl>
+                <Button sx={{ gridColumn: { xs: undefined, md: 'span 2' } }} type='submit' variant='contained'>
+                  Oppdater filtre
+                </Button>
+                <Button onClick={clearFilters} sx={{ gridColumn: { xs: undefined, md: 'span 2' } }} variant='outlined'>
+                  Fjern filtre
+                </Button>
+              </Box>
+            </AccordionDetails>
+          </Accordion>
+        </Box>
+      ) : (
+        <Stack direction='row' gap={1} sx={{ mb: 2 }}>
+          <FormControl fullWidth>
+            <InputLabel id='select-semester'>Semester</InputLabel>
+            <Select
+              id='semester'
+              label='Semester'
+              labelId='select-semester'
+              onChange={(e) => handleChange(e as SelectChangeEvent<string>, 'semester')}
+              value={matchesFilters.semester}>
+              {semesters.map((semester) => (
+                <MenuItem key={semester.id} value={semester.id}>
+                  {semester.label}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <FormControl fullWidth>
+            <InputLabel id='select-team'>Lag</InputLabel>
+            <Select
+              id='team'
+              label='Lag'
+              labelId='select-team'
+              onChange={(e) => handleChange(e as SelectChangeEvent<string>, 'team')}
+              value={matchesFilters.team}>
+              <MenuItem value=''>Alle</MenuItem>
+              {teams.map((team) => (
+                <MenuItem key={team.id} value={team.id}>
+                  {team.name}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Stack>
+      )}
+    </Stack>
   );
 };

--- a/src/components/LinkMenu.tsx
+++ b/src/components/LinkMenu.tsx
@@ -1,0 +1,46 @@
+import { Button, Stack, StackProps } from '@mui/material';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { useCallback } from 'react';
+
+export type LinkMenuProps = StackProps & {
+  routes: {
+    label: string;
+    href: string;
+  }[];
+};
+
+export const LinkMenu = ({ routes, ...props }: LinkMenuProps) => {
+  const router = useRouter();
+
+  const isCurrentRoute = useCallback((href: string) => href === router.pathname, [router]);
+
+  return (
+    <Stack direction='row' gap={1} {...props}>
+      {routes.map((route) => (
+        <Link href={route.href} key={route.href} passHref>
+          <Button
+            color='menu'
+            component='a'
+            fullWidth
+            size='large'
+            sx={{ fontWeight: isCurrentRoute(route.href) ? 'bold' : undefined }}
+            variant={isCurrentRoute(route.href) ? 'contained' : 'outlined'}>
+            {route.label}
+          </Button>
+        </Link>
+      ))}
+    </Stack>
+  );
+};
+
+export const MainLinkMenu = (props: Omit<LinkMenuProps, 'routes'>) => (
+  <LinkMenu
+    routes={[
+      { href: '/', label: 'Kalender' },
+      { href: '/statistikk', label: 'Statistikk' },
+      { href: '/oppmote', label: 'Oppmøte' },
+    ]}
+    {...props}
+  />
+);

--- a/src/components/MatchEvents.tsx
+++ b/src/components/MatchEvents.tsx
@@ -3,7 +3,7 @@ import { MatchEvent, MatchEventType, Player, Prisma } from '@prisma/client';
 import axios from 'axios';
 import { Controller, useForm } from 'react-hook-form';
 import useSWR from 'swr';
-import { fetcher } from 'utils';
+import { fetcher, MATCH_EVENT_TYPES } from 'utils';
 
 export type MatchEventsProps = {
   isAdmin?: boolean;
@@ -14,14 +14,6 @@ export type MatchEventsProps = {
       match: true;
     };
   }>;
-};
-
-const MATCH_EVENT_TYPES = {
-  [MatchEventType.GOAL]: '⚽ Mål',
-  [MatchEventType.ASSIST]: '🥈 Assist',
-  [MatchEventType.RED_CARD]: '🟥 Rødt kort',
-  [MatchEventType.YELLOW_CARD]: '🟨 Gult kort',
-  [MatchEventType.MOTM]: '🏅 MOTM',
 };
 
 type FormData = Pick<MatchEvent, 'type'> & {

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,5 +1,20 @@
 import { createTheme } from '@mui/material/styles';
 
+declare module '@mui/material/styles' {
+  interface Palette {
+    menu: Palette['primary'];
+  }
+  interface PaletteOptions {
+    menu: PaletteOptions['primary'];
+  }
+}
+
+declare module '@mui/material/Button' {
+  interface ButtonPropsColorOverrides {
+    menu: true;
+  }
+}
+
 const theme = createTheme({
   shape: {
     borderRadius: 10,
@@ -18,6 +33,10 @@ const theme = createTheme({
       light: '#35e1d0',
       main: '#03DAC5',
       dark: '#018786',
+      contrastText: '#000',
+    },
+    menu: {
+      main: '#fafafa',
       contrastText: '#000',
     },
     error: {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,1 +1,55 @@
+import { MatchEventType } from '@prisma/client';
+import { addMonths, endOfToday, getMonth, getYear, set, startOfToday } from 'date-fns';
+
 export const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+export type Semester = {
+  id: string;
+  from: Date;
+  to: Date;
+  label: string;
+};
+
+export const getSemesters = (): Semester[] => {
+  const initialDate = set(startOfToday(), { year: 2022, month: 6, date: 1 });
+  const semesters: Semester[] = [
+    {
+      id: '0',
+      from: initialDate,
+      to: set(endOfToday(), { year: 2022, month: 11, date: 31 }),
+      label: `Høst 22`,
+    },
+  ];
+
+  while (semesters[semesters.length - 1].to < new Date()) {
+    const prevSemester = semesters[semesters.length - 1];
+    const newFromDate = addMonths(prevSemester.from, 6);
+    const newToDate = addMonths(prevSemester.to, 6);
+    semesters.push({
+      id: String(Number(prevSemester.id) + 1),
+      from: newFromDate,
+      to: newToDate,
+      label: `${getMonth(newFromDate) < 7 ? 'Vår' : 'Høst'} ${String(getYear(newFromDate)).substring(2, 4)}`,
+    });
+  }
+
+  return semesters;
+};
+
+export const removeFalsyElementsFromObject = (object: Record<string, string>) => {
+  const newObject: Record<string, string> = {};
+  Object.keys(object).forEach((key) => {
+    if (object[key]) {
+      newObject[key] = object[key];
+    }
+  });
+  return newObject;
+};
+
+export const MATCH_EVENT_TYPES = {
+  [MatchEventType.GOAL]: '⚽ Mål',
+  [MatchEventType.ASSIST]: '🥈 Assist',
+  [MatchEventType.RED_CARD]: '🟥 Rødt kort',
+  [MatchEventType.YELLOW_CARD]: '🟨 Gult kort',
+  [MatchEventType.MOTM]: '🏅 MOTM',
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,7 +14,7 @@ export const getSemesters = (): Semester[] => {
   const initialDate = set(startOfToday(), { year: 2022, month: 6, date: 1 });
   const semesters: Semester[] = [
     {
-      id: '0',
+      id: 'H22',
       from: initialDate,
       to: set(endOfToday(), { year: 2022, month: 11, date: 31 }),
       label: `Høst 22`,
@@ -26,7 +26,7 @@ export const getSemesters = (): Semester[] => {
     const newFromDate = addMonths(prevSemester.from, 6);
     const newToDate = addMonths(prevSemester.to, 6);
     semesters.push({
-      id: String(Number(prevSemester.id) + 1),
+      id: `${getMonth(newFromDate) < 7 ? 'V' : 'H'}${String(getYear(newFromDate)).substring(2, 4)}`,
       from: newFromDate,
       to: newToDate,
       label: `${getMonth(newFromDate) < 7 ? 'Vår' : 'Høst'} ${String(getYear(newFromDate)).substring(2, 4)}`,
@@ -53,3 +53,9 @@ export const MATCH_EVENT_TYPES = {
   [MatchEventType.YELLOW_CARD]: '🟨 Gult kort',
   [MatchEventType.MOTM]: '🏅 MOTM',
 };
+
+export const stripEmojis = (str: string) =>
+  str
+    .replace(/([\u2700-\u27BF]|[\uE000-\uF8FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|[\u2011-\u26FF]|\uD83E[\uDD10-\uDDFF])/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();


### PR DESCRIPTION
- Ny meny på toppen av siden
- Ny side for ledertavle på match-events, den heter /statistikk. Tidligere statistikk heter nå /oppmøte
- Filtrering for arrangementer har nå to tabs, den ene går rett til kun kamper med mulighet for valg av semester (blir relevant når vi kommer over nyttår)
  - Valg av semester istedenfor fra/til brukes også på statistikk

<img width="1120" alt="image" src="https://user-images.githubusercontent.com/31009729/190895509-e464052f-1cf9-4b8b-86fa-cd0bf6d45352.png">
<img width="254" alt="image" src="https://user-images.githubusercontent.com/31009729/190895526-eaf00501-a2b4-445a-b70d-c98370e6a4e4.png">

<img width="1120" alt="image" src="https://user-images.githubusercontent.com/31009729/190895516-8e61c84f-2a16-4571-85ba-fb3215111296.png">

<img width="1120" alt="image" src="https://user-images.githubusercontent.com/31009729/190895492-e7f998c3-5486-485f-b595-360e0da22177.png">

closes #21 
closes #22 